### PR TITLE
Adding User Props to Disconnect and Fixing Topic Alias on publish

### DIFF
--- a/interoperability/mqtt/brokers/V5/MQTTBrokers.py
+++ b/interoperability/mqtt/brokers/V5/MQTTBrokers.py
@@ -148,7 +148,7 @@ class MQTTClients:
     if len(self.outgoingTopicNamesToAliases) < self.topicAliasMaximum:
       self.outgoingTopicNamesToAliases.append(topic)       # add alias
     if topic in self.outgoingTopicNamesToAliases:
-      pub.properties.TopicAlias = self.outgoingTopicNamesToAliases.index(topic)
+      pub.properties.TopicAlias = self.outgoingTopicNamesToAliases.index(topic) + 1 # Topic aliases start at 1
     else:
       pub.topicName = topic
     pub.data = msg
@@ -550,6 +550,7 @@ class MQTTBrokers:
         props = MQTTV5.Properties(MQTTV5.PacketTypes.DISCONNECT)
         props.ReasonString = "This is a custom Reason String"
         props.ServerReference = "tcp://localhost:1883"
+        props.UserPropertyList = [("key", "value")]
         self.disconnect(sock,
                         None,
                         sendWillMessage=False,


### PR DESCRIPTION
 - Added some example user properties to the server initiated disconnect.
 - Added a +1 onto all new topic aliases as 0 is not a valid topic alias.


Signed-off-by: James Sutton <james.sutton@uk.ibm.com>