### PR TITLE
Issue #45 - Removing invalid topic alias property on outgoing pub if it was set on incoming pub.

### DIFF
--- a/interoperability/mqtt/brokers/V5/MQTTBrokers.py
+++ b/interoperability/mqtt/brokers/V5/MQTTBrokers.py
@@ -144,6 +144,8 @@ class MQTTClients:
   def publishArrived(self, topic, msg, qos, properties, receivedTime, retained=False):
     pub = MQTTV5.Publishes()
     if properties:
+      if hasattr(properties, 'TopicAlias'):
+        del properties.TopicAlias
       pub.properties = properties
     logger.info("[MQTT-3.2.3-3] topic name must match the subscription's topic filter")
     # Topic alias


### PR DESCRIPTION
If an incoming publish has a topic alias set, but outgoing topic aliases are not permitted, the topic alias currently slips though and is not overridden or removed when the properties are passed over to the outgoing publish. This change checks for the "TopicAlias" attribute on the incoming message properties and deletes it before being passed to the outgoing publish.

Signed-off-by: James Sutton <james.sutton@uk.ibm.com>