### PR TITLE
Do not assign multiple aliases to one topic name

### DIFF
--- a/interoperability/mqtt/brokers/V5/MQTTBrokers.py
+++ b/interoperability/mqtt/brokers/V5/MQTTBrokers.py
@@ -151,7 +151,7 @@ class MQTTClients:
       pub.properties = properties
     logger.info("[MQTT-3.2.3-3] topic name must match the subscription's topic filter")
     # Topic alias
-    if len(self.outgoingTopicNamesToAliases) < self.topicAliasMaximum:
+    if len(self.outgoingTopicNamesToAliases) < self.topicAliasMaximum and not topic in self.outgoingTopicNamesToAliases:
       self.outgoingTopicNamesToAliases.append(topic)       # add alias
       pub.topicName = topic # include topic name as well as alias first time
     if topic in self.outgoingTopicNamesToAliases:


### PR DESCRIPTION
Might happen when multiple messages are send on one topic but
outgoingTopicNamesToAliases is not filled.

Signed-off-by: Maurice Kalinowski <webmaster@kaldience.com>