### PR TITLE
Add PSK-TLS listener

### DIFF
--- a/interoperability/client_testing.conf
+++ b/interoperability/client_testing.conf
@@ -50,4 +50,8 @@ keyfile tls_testing/keys/server/server-mitm.key
 require_certificate true
 #tls_version tlsv1
 
-
+# TLS-PSK authentication
+listener 18888
+ciphers PSK-AES128-CBC-SHA
+psk_hint Test
+psk_file test/tls-testing/mosquitto.psk

--- a/interoperability/localhost_testing.conf
+++ b/interoperability/localhost_testing.conf
@@ -47,3 +47,9 @@ certfile tls_testing/keys/server/server-mitm.crt
 keyfile tls_testing/keys/server/server-mitm.key
 require_certificate true
 #tls_version tlsv1
+
+# TLS-PSK authentication
+listener 18888
+ciphers PSK-AES128-CBC-SHA
+psk_hint Test
+psk_file test/tls-testing/mosquitto.psk


### PR DESCRIPTION
I believe this is required for the tests in this pull request to pass:
https://github.com/eclipse/paho.mqtt.c/pull/573

Signed-off-by: Johan Anderholm <johanam@axis.com>