### PR TITLE
MQTT proxy TERMINATE command fix for Python 3 and other Python code style improvements

### DIFF
--- a/interoperability/mqtt/proxy/mqttsas.py
+++ b/interoperability/mqtt/proxy/mqttsas.py
@@ -68,7 +68,7 @@ class MyHandler(socketserver.StreamRequestHandler):
               print(inbuf)
             except:
               traceback.print_exc()
-            brokers.send(inbuf)       # pass it on
+            brokers.sendall(inbuf)       # pass it on
           elif s == brokers:
             inbuf = MQTTV3.getPacket(brokers) # get one packet
             if inbuf == None:
@@ -77,7 +77,7 @@ class MyHandler(socketserver.StreamRequestHandler):
               print(timestamp(), "S to C", self.ids[id(clients)], repr(MQTTV3.unpackPacket(inbuf)))
             except:
               traceback.print_exc()
-            clients.send(inbuf)
+            clients.sendall(inbuf)
       print(timestamp()+" client "+self.ids[id(clients)]+" connection closing")
     except:
       print(repr((i, o, e)), repr(inbuf))

--- a/interoperability/mqtt/proxy/mqttsas.py
+++ b/interoperability/mqtt/proxy/mqttsas.py
@@ -44,12 +44,12 @@ class MyHandler(socketserver.StreamRequestHandler):
       clients = self.request
       brokers = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
       brokers.connect((brokerhost, brokerport))
-      while inbuf != None:
+      while inbuf is not None:
         (i, o, e) = select.select([clients, brokers], [], [])
         for s in i:
           if s == clients:
             inbuf = MQTTV3.getPacket(clients) # get one packet
-            if inbuf == None:
+            if inbuf is None:
               break
             try:
               packet = MQTTV3.unpackPacket(inbuf)
@@ -71,7 +71,7 @@ class MyHandler(socketserver.StreamRequestHandler):
             brokers.sendall(inbuf)       # pass it on
           elif s == brokers:
             inbuf = MQTTV3.getPacket(brokers) # get one packet
-            if inbuf == None:
+            if inbuf is None:
               break
             try:
               print(timestamp(), "S to C", self.ids[id(clients)], repr(MQTTV3.unpackPacket(inbuf)))

--- a/interoperability/mqtt/proxy/mqttsas.py
+++ b/interoperability/mqtt/proxy/mqttsas.py
@@ -55,7 +55,7 @@ class MyHandler(socketserver.StreamRequestHandler):
               packet = MQTTV3.unpackPacket(inbuf)
               if packet.fh.MessageType == MQTTV3.PUBLISH and \
                   packet.topicName == "MQTTSAS topic" and \
-                  packet.data == "TERMINATE":
+                  packet.data == b"TERMINATE":
                 print("Terminating client", self.ids[id(clients)])
                 brokers.close()
                 clients.close()

--- a/interoperability/mqtt/proxy/wmqttsas.py
+++ b/interoperability/mqtt/proxy/wmqttsas.py
@@ -57,7 +57,7 @@ class MyHandler(socketserver.StreamRequestHandler):
               packet = MQTTV3.unpackPacket(inbuf)
               if packet.fh.MessageType == MQTTV3.PUBLISH and \
                 packet.topicName == "MQTTSAS topic" and \
-                packet.data == "TERMINATE":
+                packet.data == b"TERMINATE":
                 print("Terminating client", self.ids[id(clients)])
                 brokers.close()
                 clients.close()

--- a/interoperability/mqtt/proxy/wmqttsas.py
+++ b/interoperability/mqtt/proxy/wmqttsas.py
@@ -74,7 +74,7 @@ class MyHandler(socketserver.StreamRequestHandler):
               print("C to S", timestamp(), repr(inbuf))
               sys.exit()
             #print "C to S", timestamp(), repr(inbuf)
-            brokers.send(inbuf)       # pass it on
+            brokers.sendall(inbuf)       # pass it on
           elif s == brokers:
             inbuf = MQTTV3.getPacket(brokers) # get one packet
             if inbuf == None:
@@ -88,7 +88,7 @@ class MyHandler(socketserver.StreamRequestHandler):
               print("S to C", timestamp(), repr(inbuf))
               sys.exit()
             #print "S to C", timestamp(), repr(inbuf)
-            clients.send(inbuf)
+            clients.sendall(inbuf)
       wx.CallAfter(myWindow.status, timestamp()+" client "+self.ids[id(clients)]+\
                    " connection closing")
     except:

--- a/interoperability/mqtt/proxy/wmqttsas.py
+++ b/interoperability/mqtt/proxy/wmqttsas.py
@@ -46,12 +46,12 @@ class MyHandler(socketserver.StreamRequestHandler):
       clients = self.request
       brokers = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
       brokers.connect((brokerhost, brokerport))
-      while inbuf != None:
+      while inbuf is not None:
         (i, o, e) = select.select([clients, brokers], [], [])
         for s in i:
           if s == clients:
             inbuf = MQTTV3.getPacket(clients) # get one packet
-            if inbuf == None:
+            if inbuf is None:
               break
             try:
               packet = MQTTV3.unpackPacket(inbuf)
@@ -77,7 +77,7 @@ class MyHandler(socketserver.StreamRequestHandler):
             brokers.sendall(inbuf)       # pass it on
           elif s == brokers:
             inbuf = MQTTV3.getPacket(brokers) # get one packet
-            if inbuf == None:
+            if inbuf is None:
               break
             try:
               wx.CallAfter(myWindow.log, timestamp(), "S to C", self.ids[id(clients)],


### PR DESCRIPTION
This patch series improve coding style for MQTT proxies written in Python.
The main fix is to allow TERMINATE command published on special MQTT topic to work again under Python version 3 runtime.