### PR TITLE
Ignore ValueError from signal.signal

### DIFF
--- a/interoperability/mqtt/brokers/start.py
+++ b/interoperability/mqtt/brokers/start.py
@@ -138,7 +138,10 @@ def run(config=None):
 
   logger.info("Python version "+sys.version)
 
-  signal.signal(signal.SIGTERM, handler)
+  try:
+    signal.signal(signal.SIGTERM, handler)
+  except ValueError:  # we are probably running in a thread
+    pass
 
   lock = threading.RLock() # shared lock
 


### PR DESCRIPTION
See hack/workaround added in https://github.com/eclipse/paho.mqtt.python/pull/781...